### PR TITLE
Added support for equipment sets

### DIFF
--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -14,6 +14,7 @@ L.Bars = {
 }
 L.Errors = {
 	UnsupportedBar = 'Unsupported bar being set. You can only set bars 1 through 8',
+	UnknownEquipmentSet = 'Unknown equipment set name in saved configuration: %s',
 }
 L.Settings = {
 	AutoLoadAtLogin = 'Automatically load at login',

--- a/UniversalBar.lua
+++ b/UniversalBar.lua
@@ -2,8 +2,8 @@ local addonName, UniversalBar = ...
 local L = UniversalBar.L
 
 -- local references
-local C_ToyBox, C_MountJournal, C_PetJournal, GetActionInfo, GetMacroInfo =
-	  C_ToyBox, C_MountJournal, C_PetJournal, GetActionInfo, GetMacroInfo
+local C_ToyBox, C_MountJournal, C_PetJournal, C_EquipmentSet, GetActionInfo, GetMacroInfo =
+	  C_ToyBox, C_MountJournal, C_PetJournal, C_EquipmentSet, GetActionInfo, GetMacroInfo
 
 -- blizzard's slotIDs are all over the place... no clue why
 local ActionBarSlotRanges = {
@@ -16,6 +16,10 @@ local ActionBarSlotRanges = {
 	[7] = { 157, 168 },
 	[8] = { 169, 180 }
 }
+
+local function PrintMessage(msg)
+	print(string.format('%s: %s', addonName, msg))
+end
 
 local function GetBarInfoForSlot(slotID)
 	for barID, range in pairs(ActionBarSlotRanges) do
@@ -145,6 +149,15 @@ function UniversalBar:LoadBarConfig()
 							elseif actionType == 'macro' then
 								PickupMacro(actionID)
 								needPlaceAction = true
+							elseif actionType == 'equipmentset' then
+								local setID = C_EquipmentSet.GetEquipmentSetID(actionID)
+								if setID then
+									C_EquipmentSet.PickupEquipmentSet(setID)
+									needPlaceAction = true
+								else
+									PrintMessage(string.format(UniversalBar.L.Errors.UnknownEquipmentSet, actionID))
+									needPlaceAction = false
+								end
 							end
 							if needPlaceAction then
 								PlaceAction(startIndex+slot-1)


### PR DESCRIPTION
Allows for cross-class sets to be named and loaded. For example, a set for "tank" on paladin and warrior will apply the equivalent equipment set in the slot for that character.

Fixes part of #2 